### PR TITLE
4_CSVインポートの準備

### DIFF
--- a/lib/import.rb
+++ b/lib/import.rb
@@ -1,0 +1,9 @@
+require "csv"
+
+class Import
+  def self.csv_data(path:)
+    list = []
+    CSV.foreach(path, headers: true) { |row| list << row.to_h }
+    list
+  end
+end

--- a/lib/tasks/import_csv.rake
+++ b/lib/tasks/import_csv.rake
@@ -1,0 +1,4 @@
+require "csv"
+
+namespace :import_csv do
+end

--- a/lib/tasks/import_csv.rake
+++ b/lib/tasks/import_csv.rake
@@ -1,4 +1,4 @@
-require "csv"
+require "../import"
 
 namespace :import_csv do
 end

--- a/lib/tasks/import_csv.rake
+++ b/lib/tasks/import_csv.rake
@@ -1,4 +1,4 @@
-require "../import"
+require_relative "../import"
 
 namespace :import_csv do
 end


### PR DESCRIPTION
- `import.rb` をlibディレクトリに追加
- `db/csv_data`ディレクトリを作成
- `import_csv`という名前でrakeタスクを作成
- `lib/tasks/import_csv.rake`から`import.rb`を読み込めるようにした
【参考資料】逆転教材Rakeタスク